### PR TITLE
Corrigindo o comportamento dos  títulos com css

### DIFF
--- a/resources/static/css/content.css
+++ b/resources/static/css/content.css
@@ -607,6 +607,7 @@ textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus {
 
 header.name {
     font-weight: bold;
+    word-wrap: anywhere;
 }
 
 .btn {


### PR DESCRIPTION
O comportamento anterior para palavras muito grandes ou frases sem espaço nos títulos era não acontecer a quebra de linha, o que quebrava o template.

Agora quando uma palavra muito grande ou frase sem espaços é inserida no template, acontece uma quebra de linha para preservar os limites do template.